### PR TITLE
Improved database queries

### DIFF
--- a/app/components/comments/actions.ts
+++ b/app/components/comments/actions.ts
@@ -85,7 +85,6 @@ export async function createComment(postId: string, text: string): Promise<Comme
 
 	await checkRateLimit();
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const thought = await get.thought.with.id(postId);
 	if (!thought) throw new Error('No need to comment on a thought that does not concern me.');
 
@@ -95,7 +94,6 @@ export async function createComment(postId: string, text: string): Promise<Comme
 			user: user.id,
 			text: validatedComment,
 		}) as unknown as Promise<typeof Comment>,
-		// @ts-expect-error RONIN queries will soon be inferred from models again.
 		get.user.with.id(user.id) as unknown as Promise<typeof User>,
 	]);
 
@@ -113,11 +111,9 @@ export async function deleteComment(commentId: string) {
 	const user = await getAuthenticatedUser();
 	if (!user) throw new Error('Not authorized to delete comment.');
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const comment = await get.comment.with.id(commentId) as typeof Comment | null;
 	if (comment?.user !== user.id) throw new Error('Not authorized to delete comment.');
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	await remove.comment.with.id(commentId);
 }
 
@@ -157,7 +153,6 @@ export async function getUserAndChallenge(username: string) {
 
 	validateUsername(username);
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const user = await get.user.with.username(username) as typeof User | null;
 
 	const publicUserId = user
@@ -256,7 +251,6 @@ export async function verifyUser(username: string, signedData: SignedData) {
 
 	await checkRateLimit();
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const user = await get.user.with.username(username) as typeof User | null;
 
 	if (!user) return null;

--- a/app/thoughts/[slug]/page.tsx
+++ b/app/thoughts/[slug]/page.tsx
@@ -34,7 +34,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
 	const resolvedParent = await parent
 
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const thought = await get.thought.with.slug(params.slug) as (typeof Thought) | null;
 
 	if (!thought) notFound();
@@ -45,7 +44,6 @@ export async function generateMetadata(
 }
 
 export default async function Page({ params }: { params: { slug: string; }}) {
-	// @ts-expect-error RONIN queries will soon be inferred from models again.
 	const thought = await get.thought.with.slug(params.slug) as (typeof Thought) | null;
 
 	if (!thought) notFound();

--- a/app/thoughts/[slug]/page.tsx
+++ b/app/thoughts/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
 	const resolvedParent = await parent
 
-	const thought = await get.thought.with.slug(params.slug) as (typeof Thought) | null;
+	const thought = await get.thought.with.slug<typeof Thought | null>(params.slug);
 
 	if (!thought) notFound();
 
@@ -44,7 +44,7 @@ export async function generateMetadata(
 }
 
 export default async function Page({ params }: { params: { slug: string; }}) {
-	const thought = await get.thought.with.slug(params.slug) as (typeof Thought) | null;
+	const thought = await get.thought.with.slug<typeof Thought | null>(params.slug);
 
 	if (!thought) notFound();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-ronin": "2.2.4",
-        "ronin": "6.0.26",
+        "ronin": "6.2.25",
         "zod": "3.22.4"
       },
       "devDependencies": {
@@ -27,6 +27,18 @@
         "typescript": "5.3.2"
       }
     },
+    "node_modules/@dprint/formatter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@dprint/formatter/-/formatter-0.4.1.tgz",
+      "integrity": "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g==",
+      "license": "MIT"
+    },
+    "node_modules/@dprint/typescript": {
+      "version": "0.93.3",
+      "resolved": "https://registry.npmjs.org/@dprint/typescript/-/typescript-0.93.3.tgz",
+      "integrity": "sha512-P/AAHYDyUG+5hih8knuk3s9n2wrCD1LSh0YsLlJMx6+v0Wsjf0PpcVRn+xDvHCtwPUctB5WBkZT2U8mu6Cm7RQ==",
+      "license": "MIT"
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -34,14 +46,14 @@
       "license": "ISC"
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.6.tgz",
-      "integrity": "sha512-PgP35JfmGjHU0LSXOyRew0zHuA9N6OJwOlos1fZ20b7j8ISeAdib3L+n0jIxBtX958UeEpte6xhG/gxJ5iUqMw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.2.tgz",
+      "integrity": "sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -50,52 +62,69 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.3.tgz",
-      "integrity": "sha512-fuF9laMmHoOgWapF9h9hv6opA5WvmGFHsTYGCmuFxcghIhEhb3dN0CdQR4BUMqa2H506NCj8cGX4jwMsE4t6dA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.6.tgz",
+      "integrity": "sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.4.tgz",
-      "integrity": "sha512-5y4/PUJVnRb4bwWY67KLdebWOhOc7xj5IP2J80oWXa64mVag24rwQ1VAdnj7/eDY/odhguW0zQ1Mp1pj6fO/2w==",
+      "version": "10.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.7.tgz",
+      "integrity": "sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
         "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^6.2.0",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.3.tgz",
-      "integrity": "sha512-S9KnIOJuTZpb9upeRSBBhoDZv7aSV3pG9TECrBj0f+ZsFwccz886hzKBrChGrXMJwd4NKY+pOA9Vy72uqnd6Eg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.7.tgz",
+      "integrity": "sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -103,16 +132,21 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.6.tgz",
-      "integrity": "sha512-TRTfi1mv1GeIZGyi9PQmvAaH65ZlG4/FACq6wSzs7Vvf1z5dnNWsAAXBjWMHt76l+1hUY8teIqJFrWBk5N6gsg==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.9.tgz",
+      "integrity": "sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -120,57 +154,72 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
-      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
+      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.3.tgz",
-      "integrity": "sha512-zeo++6f7hxaEe7OjtMzdGZPHiawsfmCZxWB9X1NpmYgbeoyerIbWemvlBxxl+sQIlHC0WuSAG19ibMq3gbhaqQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.6.tgz",
+      "integrity": "sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.6.tgz",
-      "integrity": "sha512-xO07lftUHk1rs1gR0KbqB+LJPhkUNkyzV/KhH+937hdkMazmAYHLm1OIrNKpPelppeV1FgWrgFDjdUD8mM+XUg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.9.tgz",
+      "integrity": "sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2"
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.6.tgz",
-      "integrity": "sha512-QLF0HmMpHZPPMp10WGXh6F+ZPvzWE7LX6rNoccdktv/Rov0B+0f+eyXkAcgqy5cH9V+WSpbLxu2lo3ysEVK91w==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.9.tgz",
+      "integrity": "sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -178,6 +227,11 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/prompts": {
@@ -205,13 +259,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.6.tgz",
-      "integrity": "sha512-QoE4s1SsIPx27FO4L1b1mUjVcoHm1pWE/oCmm4z/Hl+V1Aw5IXl8FYYzGmfXaBT0l/sWr49XmNSiq7kg3Kd/Lg==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.9.tgz",
+      "integrity": "sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/type": "^3.0.4",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -219,17 +273,22 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.6.tgz",
-      "integrity": "sha512-eFZ2hiAq0bZcFPuFFBmZEtXU1EarHLigE+ENCtpO+37NHCl4+Yokq1P/d09kUblObaikwfo97w+0FtG/EXl5Ng==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.9.tgz",
+      "integrity": "sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.4",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -237,17 +296,22 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.6.tgz",
-      "integrity": "sha512-yANzIiNZ8fhMm4NORm+a74+KFYHmf7BZphSOBovIzYPVLquseTGEkU5l2UTnBOf5k0VLmTgPighNDLE9QtbViQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.9.tgz",
+      "integrity": "sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.4",
-        "@inquirer/figures": "^1.0.9",
-        "@inquirer/type": "^3.0.2",
+        "@inquirer/core": "^10.1.7",
+        "@inquirer/figures": "^1.0.10",
+        "@inquirer/type": "^3.0.4",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -256,18 +320,28 @@
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.2.tgz",
-      "integrity": "sha512-ZhQ4TvhwHZF+lGhQ2O/rsjo80XoZR5/5qhOY3t6FJuX5XBg5Be8YzYTvaUGJnc12AUGI2nr4QSUE4PhKSigx7g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
+      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@next/env": {
@@ -457,11 +531,13 @@
       }
     },
     "node_modules/@ronin/cli": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@ronin/cli/-/cli-0.2.29.tgz",
-      "integrity": "sha512-geSkWFwUhly/a76vAIDXFURb8crbDMudxO5opNy1DomfsQMVWEJTUX+jNOp/ySYifEpA3+LCuYFoXcLoyCwI3A==",
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/@ronin/cli/-/cli-0.2.40.tgz",
+      "integrity": "sha512-UTs0bCjO7vTYpCp9o9QJQrcP7X9vFQxl8nBBdHI786rgJLDbpMo0tUF3bwEFrQMCLx6J+VwsIW/Umn4EcMBzyw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dprint/formatter": "0.4.1",
+        "@dprint/typescript": "0.93.3",
         "@iarna/toml": "2.2.5",
         "@inquirer/prompts": "7.2.3",
         "@ronin/engine": "0.0.27",
@@ -471,29 +547,13 @@
         "json5": "2.2.3",
         "open": "10.1.0",
         "ora": "8.1.1",
-        "prettier": "3.4.2",
         "resolve-from": "5.0.0"
       }
     },
-    "node_modules/@ronin/cli/node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@ronin/compiler": {
-      "version": "0.14.14",
-      "resolved": "https://registry.npmjs.org/@ronin/compiler/-/compiler-0.14.14.tgz",
-      "integrity": "sha512-TqvEdP7p9ub7SeV5wnoO7tT11Z+uKjGTsq648Ye7o3n30t34XhTAqhk6w/VNQ8yMKMa7V19UroSeL2hR0Qclqg==",
+      "version": "0.17.15",
+      "resolved": "https://registry.npmjs.org/@ronin/compiler/-/compiler-0.17.15.tgz",
+      "integrity": "sha512-c6+s4VXNKsmogWy+WZYXc91q7usQFx3EEE5ow8jW1lK9yKDBlHXPQxWbkVS+FxYFcNOqbbI08QDUVN7WuyaiLQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@ronin/engine": {
@@ -514,9 +574,9 @@
       }
     },
     "node_modules/@ronin/syntax": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@ronin/syntax/-/syntax-0.2.12.tgz",
-      "integrity": "sha512-AMKv/yDiD92xbVLHOYiTmAeh+BYpr65JxxuGUC/nVfZwg+Ti3uga81L3J3FWFeKnu3e7Fl2G4JpHgSlHO3DvgQ==",
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@ronin/syntax/-/syntax-0.2.34.tgz",
+      "integrity": "sha512-/XXb2WApKThG7EYfTUitHnCqKZfnCNvFQ31krSkVQ95On95Ts9qYDYA/qU7epBgy0LwAOvH6cHfWZV5W4S+fig==",
       "license": "Apache-2.0"
     },
     "node_modules/@swc/counter": {
@@ -642,12 +702,15 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1234,33 +1297,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -1415,14 +1451,14 @@
       }
     },
     "node_modules/ronin": {
-      "version": "6.0.26",
-      "resolved": "https://registry.npmjs.org/ronin/-/ronin-6.0.26.tgz",
-      "integrity": "sha512-spe2m0Ex+mrVKnpXKlfriXEoRqXx4lJesWVYO27ZzPnYalgsm7YMwe3sU0LGkU/fRKb9IFn+3rGkH+QrwV5tUg==",
+      "version": "6.2.25",
+      "resolved": "https://registry.npmjs.org/ronin/-/ronin-6.2.25.tgz",
+      "integrity": "sha512-T0pcIuZ+JeDQlMht+qjIJUVWefYLjlVSbf/8KvqGoAnpnANEbBG/0qQWW/qd2Fgq3BosNcRqeM2RNM2oghmOAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ronin/cli": "0.2.29",
-        "@ronin/compiler": "0.14.14",
-        "@ronin/syntax": "0.2.12"
+        "@ronin/cli": "0.2.40",
+        "@ronin/compiler": "0.17.15",
+        "@ronin/syntax": "0.2.34"
       },
       "bin": {
         "ronin": "dist/bin/index.js"
@@ -1516,19 +1552,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
@@ -1541,18 +1565,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/styled-jsx": {
@@ -1642,6 +1654,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1657,6 +1678,18 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-ronin": "2.2.4",
-    "ronin": "6.0.26",
+    "ronin": "6.2.25",
     "zod": "3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This change upgrades the `ronin` client to the latest version, which at the time of writing is version `6.2.25`, which fixes a number of type errors that have previously been suppressed until now.

As such I have also removed those type suppressions. Along with some other minor refactoring to use the available type argument for database queries instead of using type assertions.