### PR TITLE
Added automatic database types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ node_modules
 .env*.local
 
 # database
-.ronin
+.ronin/config.json
 .protocols

--- a/.ronin/types.d.ts
+++ b/.ronin/types.d.ts
@@ -1,0 +1,116 @@
+import type { AddQuery, CountQuery, GetQuery, RemoveQuery, SetQuery } from "@ronin/compiler";
+import type { DeepCallable, ResultRecord } from "@ronin/syntax/queries";
+import type { QueryHandlerOptions } from "ronin/types";
+type ResolveSchema<TSchema, TUsing extends Array<string> | "all", TKey extends string> = TUsing extends "all" ? TSchema : TKey extends TUsing[number] ? TSchema : TSchema extends Array<any> ? Array<string> : string;
+declare module "ronin" {
+    export type Thought = ResultRecord & {
+        externalLink: string;
+        hidden: boolean;
+        postedAt: Date;
+        slug: string;
+        text: object;
+        title: string;
+    };
+    export type Thoughts = Array<Thought> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
+    export type User = ResultRecord & {
+        publicKey: object;
+        publicUserId: string;
+        username: string;
+    };
+    export type Users = Array<User> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
+    export type Comment<TUsing extends Array<"thought" | "user"> | "all" = [
+    ]> = ResultRecord & {
+        text: string;
+        thought: ResolveSchema<Thought, TUsing, "thought">;
+        user: ResolveSchema<User, TUsing, "user">;
+    };
+    export type Comments<TUsing extends Array<"thought" | "user"> | "all" = [
+    ]> = Array<Comment<TUsing>> & {
+        moreBefore?: string;
+        moreAfter?: string;
+    };
+    declare const add: {
+        /* Add a single Thought record */
+        thought: DeepCallable<AddQuery[keyof AddQuery], Thought | null>;
+        /* Add a single User record */
+        user: DeepCallable<AddQuery[keyof AddQuery], User | null>;
+        /* Add a single Comment record */
+        comment: DeepCallable<AddQuery[keyof AddQuery], Comment | null>;
+    };
+    declare const count: {
+        /* Count a single Thought record */
+        thought: DeepCallable<CountQuery[keyof CountQuery], Thought | null>;
+        /* Count multiple Thought records */
+        thoughts: DeepCallable<CountQuery[keyof CountQuery], Thoughts>;
+        /* Count a single User record */
+        user: DeepCallable<CountQuery[keyof CountQuery], User | null>;
+        /* Count multiple User records */
+        users: DeepCallable<CountQuery[keyof CountQuery], Users>;
+        /* Count a single Comment record */
+        comment: DeepCallable<CountQuery[keyof CountQuery], Comment | null>;
+        /* Count multiple Comment records */
+        comments: DeepCallable<CountQuery[keyof CountQuery], Comments>;
+    };
+    declare const get: {
+        /* Get a single Thought record */
+        thought: DeepCallable<GetQuery[keyof GetQuery], Thought | null>;
+        /* Get multiple Thought records */
+        thoughts: DeepCallable<GetQuery[keyof GetQuery], Thoughts>;
+        /* Get a single User record */
+        user: DeepCallable<GetQuery[keyof GetQuery], User | null>;
+        /* Get multiple User records */
+        users: DeepCallable<GetQuery[keyof GetQuery], Users>;
+        /* Get a single Comment record */
+        comment: DeepCallable<GetQuery[keyof GetQuery], Comment | null>;
+        /* Get multiple Comment records */
+        comments: DeepCallable<GetQuery[keyof GetQuery], Comments>;
+    };
+    declare const remove: {
+        /* Remove a single Thought record */
+        thought: DeepCallable<RemoveQuery[keyof RemoveQuery], Thought | null>;
+        /* Remove multiple Thought records */
+        thoughts: DeepCallable<RemoveQuery[keyof RemoveQuery], Thoughts>;
+        /* Remove a single User record */
+        user: DeepCallable<RemoveQuery[keyof RemoveQuery], User | null>;
+        /* Remove multiple User records */
+        users: DeepCallable<RemoveQuery[keyof RemoveQuery], Users>;
+        /* Remove a single Comment record */
+        comment: DeepCallable<RemoveQuery[keyof RemoveQuery], Comment | null>;
+        /* Remove multiple Comment records */
+        comments: DeepCallable<RemoveQuery[keyof RemoveQuery], Comments>;
+    };
+    declare const set: {
+        /* Set a single Thought record */
+        thought: DeepCallable<SetQuery[keyof SetQuery], Thought | null>;
+        /* Set multiple Thought records */
+        thoughts: DeepCallable<SetQuery[keyof SetQuery], Thoughts>;
+        /* Set a single User record */
+        user: DeepCallable<SetQuery[keyof SetQuery], User | null>;
+        /* Set multiple User records */
+        users: DeepCallable<SetQuery[keyof SetQuery], Users>;
+        /* Set a single Comment record */
+        comment: DeepCallable<SetQuery[keyof SetQuery], Comment | null>;
+        /* Set multiple Comment records */
+        comments: DeepCallable<SetQuery[keyof SetQuery], Comments>;
+    };
+    declare const createSyntaxFactory: (options: QueryHandlerOptions | (() => QueryHandlerOptions)) => {
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
+    };
+    export default function (options: QueryHandlerOptions | (() => QueryHandlerOptions)): {
+        add: typeof add;
+        count: typeof count;
+        get: typeof get;
+        remove: typeof remove;
+        set: typeof set;
+    };
+}

--- a/app/components/comments/comment-list.tsx
+++ b/app/components/comments/comment-list.tsx
@@ -33,8 +33,7 @@ export function CommentList({
 		<div className={styles.commentList}>
 			<div>
 				{comments.map(list => {
-					return list.comments.map(defaultComment => {
-						const comment = defaultComment as CommentWithUser & { ronin: { createdAt: Date } };
+					return list.comments.map(comment => {
 						const date = new Date(comment.ronin.createdAt).toISOString();
 
 						return (

--- a/app/components/comments/index.tsx
+++ b/app/components/comments/index.tsx
@@ -19,9 +19,7 @@ export function Comments({ postId }: { postId: string }) {
 	const moreAfter = comments[comments.length - 1]?.moreAfter;
 	const hasMore = Boolean(moreAfter);
 
-	const unshiftComment = useCallback(async (defaultComment: CommentWithUser) => {
-		const comment = defaultComment as CommentWithUser & { ronin: { createdAt: Date } };
-
+	const unshiftComment = useCallback(async (comment: CommentWithUser) => {
 		setComments((prev) => {
 			const next = [
 				{

--- a/app/thoughts/[slug]/page.tsx
+++ b/app/thoughts/[slug]/page.tsx
@@ -14,7 +14,7 @@ type Props = {
 export const revalidate = 60; // Revalidate every minute
 
 export async function generateStaticParams() {
-	const thoughts = await get.thoughts.orderedBy.descending(['postedAt']) as Array<typeof Thought>;
+	const thoughts = await get.thoughts.orderedBy.descending(['postedAt']);
 
 	const params: { slug: string; }[] = [];
 

--- a/app/thoughts/page.tsx
+++ b/app/thoughts/page.tsx
@@ -7,7 +7,7 @@ import type { Thought } from '../../schema';
 export const revalidate = 60;
 
 export default async function Thoughts() {
-	const thoughts = await get.thoughts.orderedBy.descending(['postedAt']) as Array<typeof Thought>;
+	const thoughts = await get.thoughts.orderedBy.descending(['postedAt']);
 
 	return (
 		<>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "next": "15.2.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "ronin": "6.2.26",
+        "ronin": "^6.4.3",
         "zod": "3.24.2"
       },
       "devDependencies": {
@@ -84,14 +84,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.2.tgz",
-      "integrity": "sha512-PL9ixC5YsPXzXhAZFUPmkXGxfgjkdfZdPEPPmt4kFwQ4LBMDG9n/nHXYRGGZSKZJs+d1sGKWgS2GiPzVRKUdtQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
+      "integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -108,13 +108,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.6.tgz",
-      "integrity": "sha512-6ZXYK3M1XmaVBZX6FCfChgtponnL0R6I7k8Nu+kaoNkT828FVZTcca1MqmWQipaW2oNREQl5AaPCUOOCVNdRMw==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+      "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -129,13 +129,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.7.tgz",
-      "integrity": "sha512-AA9CQhlrt6ZgiSy6qoAigiA1izOa751ugX6ioSjqgJ+/Gd+tEN/TORk5sUYNjXuHWfW0r1n/a6ak4u/NqHHrtA==",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -156,13 +156,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.7.tgz",
-      "integrity": "sha512-gktCSQtnSZHaBytkJKMKEuswSk2cDBuXX5rxGFv306mwHfBPjg5UAldw9zWGoEyvA9KpRDkeM4jfrx0rXn0GyA==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -178,13 +178,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.9.tgz",
-      "integrity": "sha512-Xxt6nhomWTAmuSX61kVgglLjMEFGa+7+F6UUtdEUeg7fg4r9vaFttUUKrtkViYYrQBA5Ia1tkOJj2koP9BuLig==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
+      "integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -200,22 +200,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
-      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.6.tgz",
-      "integrity": "sha512-1f5AIsZuVjPT4ecA8AwaxDFNHny/tSershP/cTvTDxLdiIGTeILNcKozB0LaYt6mojJLUbOYhpIxicaYf7UKIQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
+      "integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -230,13 +230,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.9.tgz",
-      "integrity": "sha512-iN2xZvH3tyIYXLXBvlVh0npk1q/aVuKXZo5hj+K3W3D4ngAEq/DkLpofRzx6oebTUhBvOgryZ+rMV0yImKnG3w==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
+      "integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -251,13 +251,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.9.tgz",
-      "integrity": "sha512-xBEoOw1XKb0rIN208YU7wM7oJEHhIYkfG7LpTJAEW913GZeaoQerzf5U/LSHI45EVvjAdgNXmXgH51cUXKZcJQ==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
+      "integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -297,13 +297,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.9.tgz",
-      "integrity": "sha512-+5t6ebehKqgoxV8fXwE49HkSF2Rc9ijNiVGEQZwvbMI61/Q5RcD+jWD6Gs1tKdz5lkI8GRBL31iO0HjGK1bv+A==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
+      "integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -319,14 +319,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.9.tgz",
-      "integrity": "sha512-DWmKztkYo9CvldGBaRMr0ETUHgR86zE6sPDVOHsqz4ISe9o1LuiWfgJk+2r75acFclA93J/lqzhT0dTjCzHuoA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
+      "integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -342,14 +342,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.9.tgz",
-      "integrity": "sha512-BpJyJe7Dkhv2kz7yG7bPSbJLQuu/rqyNlF1CfiiFeFwouegfH+zh13KDyt6+d9DwucKo7hqM3wKLLyJxZMO+Xg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
+      "integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.7",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
-      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/@ronin/cli": {
-      "version": "0.2.40",
-      "resolved": "https://registry.npmjs.org/@ronin/cli/-/cli-0.2.40.tgz",
-      "integrity": "sha512-UTs0bCjO7vTYpCp9o9QJQrcP7X9vFQxl8nBBdHI786rgJLDbpMo0tUF3bwEFrQMCLx6J+VwsIW/Umn4EcMBzyw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@ronin/cli/-/cli-0.3.0.tgz",
+      "integrity": "sha512-LfxwS5C0U/VdrAREEuq0VMoVgRIqVZdcjYkSX/abfU6xi+op7u5V4kfTaR9Ip4tgZFRHfFNR0CWQ+UhR8jfgxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@ronin/compiler": {
-      "version": "0.17.15",
-      "resolved": "https://registry.npmjs.org/@ronin/compiler/-/compiler-0.17.15.tgz",
-      "integrity": "sha512-c6+s4VXNKsmogWy+WZYXc91q7usQFx3EEE5ow8jW1lK9yKDBlHXPQxWbkVS+FxYFcNOqbbI08QDUVN7WuyaiLQ==",
+      "version": "0.17.21",
+      "resolved": "https://registry.npmjs.org/@ronin/compiler/-/compiler-0.17.21.tgz",
+      "integrity": "sha512-Vvv0y7kMqrAwn4JJU/QJPhLVjwHW+CKDY3PwbGKe1ldIGBvWkBdvwx3YVvdWGhskvQ+g1s0pFDf304SRYqXtSQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@ronin/engine": {
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@ronin/syntax": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@ronin/syntax/-/syntax-0.2.34.tgz",
-      "integrity": "sha512-/XXb2WApKThG7EYfTUitHnCqKZfnCNvFQ31krSkVQ95On95Ts9qYDYA/qU7epBgy0LwAOvH6cHfWZV5W4S+fig==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@ronin/syntax/-/syntax-0.2.37.tgz",
+      "integrity": "sha512-AvCh2IfImNRFARYS/uRWBj1r7KEhULwyQ8zUdKZ/mIvJM1fdrSVRezL/5Ud6ZPCFcQRJBlky7xojWt0n/qYPWw==",
       "license": "Apache-2.0"
     },
     "node_modules/@swc/counter": {
@@ -1486,14 +1486,14 @@
       }
     },
     "node_modules/ronin": {
-      "version": "6.2.26",
-      "resolved": "https://registry.npmjs.org/ronin/-/ronin-6.2.26.tgz",
-      "integrity": "sha512-QJJyzBrFtH2DBVPBbSwfBOoQIScMmr31QKv8Ze/Jc6UbacNe54n9jSZsVbi8wuDdGw2JiWHId/6uVeOFdCdDOQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/ronin/-/ronin-6.4.3.tgz",
+      "integrity": "sha512-Ac9x4UAM7uE8PqAJbMsYrvf/saoWNH0aK3fCNTyqh32lK201lzXv4mS7W9HCsSAfjGP+rrZ4ojCFpEEJeOhUBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ronin/cli": "0.2.40",
-        "@ronin/compiler": "0.17.15",
-        "@ronin/syntax": "0.2.34"
+        "@ronin/cli": "0.3.0",
+        "@ronin/compiler": "0.17.21",
+        "@ronin/syntax": "0.2.37"
       },
       "bin": {
         "ronin": "dist/bin/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -404,25 +404,109 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-      "license": "MIT",
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
+      "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "node": ">= 10"
       }
     },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
-      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
+      "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
+      "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
+      "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
+      "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
+      "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
+      "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
@@ -542,15 +626,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.13.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
@@ -569,12 +644,6 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-      "license": "MIT"
     },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.10",
@@ -1144,15 +1213,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -1317,15 +1377,6 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1407,385 +1458,6 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
-      }
-    },
-    "node_modules/react-ronin": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/react-ronin/-/react-ronin-2.3.3.tgz",
-      "integrity": "sha512-phwD20aoKFKH5apt4lI678qFkdh7+XtraDGhXLDCSePx7b/tmdmS/C7YvIj+dFwMzJF9vr4QZnn5knBpnHgoNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ronin": "4.2.2"
-      },
-      "peerDependencies": {
-        "react": ">=18.3.1"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/checkbox": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
-      "integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
-      "integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "external-editor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/expand": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
-      "integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/input": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
-      "integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/number": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
-      "integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/prompts": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.3.4.tgz",
-      "integrity": "sha512-rZQewXIV6yZXuZtZ65/WIhcND0RCOQZtu0uPEST7wZStLQwuZCD3rZrD1fuxygqzqA5rGq7pgSuLmhGCuSnkkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^2.4.3",
-        "@inquirer/confirm": "^3.1.18",
-        "@inquirer/editor": "^2.1.18",
-        "@inquirer/expand": "^2.1.18",
-        "@inquirer/input": "^2.2.5",
-        "@inquirer/number": "^1.0.6",
-        "@inquirer/password": "^2.1.18",
-        "@inquirer/rawlist": "^2.2.0",
-        "@inquirer/search": "^1.0.3",
-        "@inquirer/select": "^2.4.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/rawlist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
-      "integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/search": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
-      "integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/select": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
-      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/react-ronin/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-ronin/node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-ronin/node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/react-ronin/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/react-ronin/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-ronin/node_modules/ora": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
-      "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "cli-cursor": "^4.0.0",
-        "cli-spinners": "^2.9.2",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-ronin/node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-ronin/node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
-    "node_modules/react-ronin/node_modules/ronin": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ronin/-/ronin-4.2.2.tgz",
-      "integrity": "sha512-MAGpRgFeGQb9lo5h7HPUtiTLbinFzhSeAmQiaFr1crzTMjvmusA+fYGInV487VSo2M4f90BMGaO6PA1Mn8waDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@iarna/toml": "2.2.5",
-        "@inquirer/prompts": "5.3.4",
-        "@paralleldrive/cuid2": "2.2.2",
-        "chalk-template": "1.1.0",
-        "get-port": "7.1.0",
-        "ini": "4.1.3",
-        "json5": "2.2.3",
-        "open": "10.1.0",
-        "ora": "8.0.1",
-        "pluralize": "8.0.0",
-        "typescript": "5.5.4"
-      },
-      "bin": {
-        "ronin": "dist/bin/index.js"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/react-ronin/node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/resolve-from": {
@@ -2137,111 +1809,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
-      "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
-      "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
-      "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
-      "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
-      "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
-      "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
-      "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "next": "15.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "ronin": "6.2.26",
+    "ronin": "^6.4.3",
     "zod": "3.24.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "generate": "ronin types"
   },
   "repository": "AndyBitz/site",
   "author": "AndyBitz",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".ronin/*.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This change upgrades the `ronin` client to version `6.4.3` which includes the introduction of the new `ronin types` command to generate automatic types. As such some cleanup has been made to remove type assertions where needed.